### PR TITLE
Add some textiles dependencies

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -9,6 +9,7 @@
 * [Install GLib](install_glib.md)
 * [Install KDL](install_kdl.md)
 * [Install MBROLA](install_mbrola.md)
+* [Install NumPy](install-numpy.md)
 * [Install OpenCV](install_opencv.md)
 * [Install OpenNI2 & NiTE2](install_openni_nite.md)
 * [Install OpenRAVE](install_openrave.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -14,9 +14,10 @@
 * [Install OpenRAVE](install_openrave.md)
 * [Install OROCOS KDL](install_orocos_kdl.md)
 * [Install PCL](install_pcl.md)
+* Install pip
 * [Install Pygame](install_pygame.md)
+* [Install Scikit-Image](install-scikit-image.md)
 * [Install Speech Recognition](install_speech_recognition.md)
 * [Install Travis](install_travis.md)
 * [Install YARP](install_yarp.md)
-* [Install Scikit-Image](install-scikit-image.md)
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -14,7 +14,7 @@
 * [Install OpenRAVE](install_openrave.md)
 * [Install OROCOS KDL](install_orocos_kdl.md)
 * [Install PCL](install_pcl.md)
-* Install pip
+* [Install pip](install-pip.md)
 * [Install Pygame](install_pygame.md)
 * [Install Scikit-Image](install-scikit-image.md)
 * [Install Speech Recognition](install_speech_recognition.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,5 +1,6 @@
 # Summary
 
+* [Introduction](README.md)
 * [Install Aquila](install_aquila.md)
 * [Install Boost](install_boost.md)
 * [Install CMake](install_cmake.md)
@@ -17,4 +18,5 @@
 * [Install Speech Recognition](install_speech_recognition.md)
 * [Install Travis](install_travis.md)
 * [Install YARP](install_yarp.md)
+* [Install Scikit-Image](install-scikit-image.md)
 

--- a/install-numpy.md
+++ b/install-numpy.md
@@ -1,0 +1,16 @@
+# Install NumPy
+
+[NumPy](http://www.numpy.org/) NumPy is the fundamental package for scientific computing with Python.
+
+## Install latest NumPy using pip
+This requires [pip](install-pip.md). (Use `pip3` to install the Python 3 version of NumPy):
+
+```bash
+$ sudo -H pip install numpy
+```
+
+# Install Numpy using the Ubuntu package manager
+
+```bash
+$ sudo apt-get install python-numpy
+```

--- a/install-pip.md
+++ b/install-pip.md
@@ -1,0 +1,13 @@
+#Install pip
+
+Pip is the  [PyPA recommended tool](https://packaging.python.org/current/) for installing Python packages.
+
+[Official website](https://pypi.python.org/pypi/pip).
+
+## Install latest pip on GNU/Linux
+(Use `python3` instead for installing the Python 3 version, `pip3`)
+
+```bash
+$ wget https://bootstrap.pypa.io/get-pip.py
+$ sudo python get-pip.py
+```

--- a/install-scikit-image.md
+++ b/install-scikit-image.md
@@ -1,0 +1,30 @@
+# Install Scikit-Image
+
+[Scikit-image](http://scikit-image.org/) is a Python library for computer vision. Installation using `pip` is quite straightforward.
+
+Note that you will be prompted for your password upon using sudo a couple of times.
+
+## Install stable version
+Installing the stable version is simple (Use `pip3` instead to install the Python 3 version):
+
+```bash
+$ sudo -H pip install scikit-image
+```
+
+## Install development version (pre-0.13)
+The development version has to be compiled from the source code. Here are the steps (Use `pip3` instead to install the Python 3 version):
+
+1. Clone development repository:
+```bash
+$ git clone https://github.com/scikit-image/scikit-image.git
+```
+2. Upgrade Cython to version `cython>=0.21` (if that version isn't already installed)
+```bash
+$ sudo -H pip install --upgrade cython
+```
+3. Installation:
+```bash
+$ cd scikit-image
+$ sudo -H pip install -e .
+```
+

--- a/install_opencv.md
+++ b/install_opencv.md
@@ -79,5 +79,17 @@ The last step can also be done by hand using `ccmake`.
 $ make
 $ sudo make install
 ```
+
 ## Install OpenCV 3 (With contrib, Python 3 support and fix for SVM_load)
-ToDo
+OpenCV 3 has no method to load the SVM unless the specific commit where this was fixed is used (see [this](https://github.com/opencv/opencv/issues/4969) and [this](https://github.com/roboticslab-uc3m/textiles/issues/20) for related info).
+
+To install OpenCV 3 with support for SVM loading, follow the previous steps, executing the following commands after step 10: 
+
+```bash
+$ cd ../opencv
+$ git checkout 37cbcf024c2b4160648299887a7c28d7cf28b1d3
+$ cd ../opencv_contrib
+$ git checkout 5409d5ad560523c85c6796cc5a009347072d883c
+```
+
+Then, continue with the previous guide, executing steps 11 and 12.

--- a/install_opencv.md
+++ b/install_opencv.md
@@ -40,11 +40,44 @@ $ sudo apt-get install python3.4-dev
 ```
 
 7. [Install pip](install-pip.md)
-7. [Install Numpy](install-numpy.md)
+8. [Install Numpy](install-numpy.md)
 ```
-$ pip install numpy
+$ sudo -H pip install numpy
 ```
+9. Download OpenCV main repo
+```
+$ mkdir -p repos
+$ cd repos
+$ git clone https://github.com/Itseez/opencv.git
+$ cd opencv
+$ git checkout 3.0.0
+```
+10. Download OpenCV contrib repo
+```
+$ cd ..
+$ git clone https://github.com/Itseez/opencv_contrib.git
+$ cd opencv_contrib
+$ git checkout 3.0.0
+```
+11. Configure OpenCV main repo
+```
+$ cd ../opencv
+$ mkdir build
+$ cd build
+$ cmake -D CMAKE_BUILD_TYPE=RELEASE \
+	-D CMAKE_INSTALL_PREFIX=/usr/local \
+	-D INSTALL_C_EXAMPLES=ON \
+	-D INSTALL_PYTHON_EXAMPLES=ON \
+	-D OPENCV_EXTRA_MODULES_PATH=~/opencv_contrib/modules \
+	-D BUILD_EXAMPLES=ON ..
+```
+The last step can also be done by hand using `ccmake`.
 
-
+12. Compile and install
+(This will probably take a long time, use the `-j` flag to speed up things using multithreaded compilation)
+```
+$ make
+$ sudo make install
+```
 ## Install OpenCV 3 (With contrib, Python 3 support and fix for SVM_load)
 ToDo

--- a/install_opencv.md
+++ b/install_opencv.md
@@ -7,3 +7,44 @@ We use OpenCV for real-time computer vision. Official download page: [link](http
 ```bash
 sudo apt-get install libopencv-dev
 ```
+
+## Install OpenCV 3 (With contrib and Python 3 support)
+Adapted from [this post](http://www.pyimagesearch.com/2015/07/20/install-opencv-3-0-and-python-3-4-on-ubuntu/).
+
+1. Upgrade any pre-installed packages:
+```bash
+$ sudo apt-get update
+$ sudo apt-get upgrade
+```	
+2. Install developer tools used to compile OpenCV 3.0:
+```bash
+$ sudo apt-get install build-essential cmake git pkg-config
+```
+3. Install libraries and packages used to read various image and video formats from disk:
+```bash
+$ sudo apt-get install libjpeg8-dev libtiff4-dev libjasper-dev libpng12-dev
+$ sudo apt-get install libavcodec-dev libavformat-dev libswscale-dev libv4l-dev
+```
+4. Install GTK so we can use OpenCV’s GUI features:
+```	
+$ sudo apt-get install libgtk2.0-dev
+```
+5. Install packages that are used to optimize various functions inside OpenCV, such as matrix operations:
+```
+$ sudo apt-get install libatlas-base-dev gfortran
+```
+
+6. Install the Python 3.4+ headers and development files:
+```
+$ sudo apt-get install python3.4-dev
+```
+
+7. [Install Numpy]()
+```
+$ pip install numpy
+```
+	
+$ pip install numpy
+
+## Install OpenCV 3 (With contrib, Python 3 support and fix for SVM_load)
+ToDo

--- a/install_opencv.md
+++ b/install_opencv.md
@@ -39,12 +39,12 @@ $ sudo apt-get install libatlas-base-dev gfortran
 $ sudo apt-get install python3.4-dev
 ```
 
-7. [Install Numpy]()
+7. [Install pip](install-pip.md)
+7. [Install Numpy](install-numpy.md)
 ```
 $ pip install numpy
 ```
-	
-$ pip install numpy
+
 
 ## Install OpenCV 3 (With contrib, Python 3 support and fix for SVM_load)
 ToDo


### PR DESCRIPTION
I have started documenting all these dependencies in [a fork of the organization installation guides](https://github.com/David-Estevez/installation-guides). Right now, the following dependencies are documented:
* OpenCV 3 (with Python3 support and SVM_load support)
* NumPy
* Pip
* Scikit-learn (stable and pre-release versions)
