### PR TITLE
replacement of apt-get -> apt 

### DIFF
--- a/install-aquila.md
+++ b/install-aquila.md
@@ -7,7 +7,7 @@ Official page: [link](http://aquila-dsp.org/)
 ## Install Aquila (Ubuntu)
 
 ```bash
-sudo apt-get install libsfml-dev
+sudo apt install libsfml-dev
 cd  # go home
 mkdir -p repos; cd repos  # create $HOME/repos if it doesn't exist; then, enter it
 git clone git://github.com/zsiciarz/aquila.git

--- a/install-aravis.md
+++ b/install-aravis.md
@@ -7,7 +7,7 @@ sudo apt install glib-2.0 gobject-2.0 gio-2.0 libxml-2.0 thread-2.0 zlib gstream
 ```
 3. Install even more dependiencies:
 ```
-sudo apt-get install autoconf intltool python-gobject-dev gobject-introspection gtk-doc-tools libgstreamer0.10-dev python-gst0.10-dev libxml2-dev
+sudo apt install autoconf intltool python-gobject-dev gobject-introspection gtk-doc-tools libgstreamer0.10-dev python-gst0.10-dev libxml2-dev
 ```
 4. Uncompress the downloaded Aravis package and open a terminal in that folder.
 5. Run `autogen.sh`
@@ -23,7 +23,7 @@ The most common are:
 Builds the aravis example application that allows basic interaction with your camera. The viewer needs GTK+3 and libnotify. You can install them with
 
 ```
-sudo apt-get install libgtk-3-dev libnotify-dev libgstreamer1.0 libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-bad
+sudo apt install libgtk-3-dev libnotify-dev libgstreamer1.0 libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-bad
 ```
 
 ##### --enable-gst-plugin 

--- a/install-boost.md
+++ b/install-boost.md
@@ -7,7 +7,7 @@ This package contains the Boost C++ Libraries development files.
 Installing Boost on Ubuntu is quite straightforward. Note that you will be prompted for your password upon using `sudo`. Type:
 
 ```bash
-sudo apt-get install libboost-dev
+sudo apt install libboost-dev
 ```
 
 ## Install Boost (Windows)

--- a/install-build-essential.md
+++ b/install-build-essential.md
@@ -5,5 +5,5 @@ This package is needed for working with Debian packages.
 Installing build-essentials on Ubuntu is quite straightforward. Note that you will be prompted for your password upon using sudo. Type:
 
 ```bash
-sudo apt-get install build-essential
+sudo apt install build-essential
 ```

--- a/install-cmake.md
+++ b/install-cmake.md
@@ -9,8 +9,8 @@ Official download page: [link](https://cmake.org/download/)
 Installing CMake on Ubuntu is quite straightforward. Note that you will be prompted for your password upon using `sudo`. Type:
 
 ```bash
-sudo apt-get install cmake
-sudo apt-get install cmake-curses-gui  # Recommended, as it contains ccmake.
+sudo apt install cmake
+sudo apt install cmake-curses-gui  # Recommended, as it contains ccmake.
 ```
 
 ### Ubuntu 14.04 backports
@@ -18,9 +18,9 @@ sudo apt-get install cmake-curses-gui  # Recommended, as it contains ccmake.
 CMake packages up to release 2.8.12 are distributed on Ubuntu Trusty (14.04). However, a CMake 3.5 backport is also included in the oficial repositories.
 
 ```bash
-sudo apt-get update
-sudo apt-get install cmake3
-sudo apt-get install cmake3-curses-gui  # Recommended, includes ccmake
+sudo apt update
+sudo apt install cmake3
+sudo apt install cmake3-curses-gui  # Recommended, includes ccmake
 ```
 
 ### Ubuntu 12.04 backports
@@ -38,8 +38,8 @@ sudo apt-get install cmake
 Older versions were reported to lack OpenSSL support needed for downloading external data through `file(DOWNLOAD)` commands. In that case, you'll need to install any required dependencies and compile CMake by yourself. E.g. for CMake 2.8.9 on Ubuntu 12.04:
 
 ```bash
-sudo apt-get install cmake # get CMake 2.8.7 first
-sudo apt-get install libcurl4-openssl-dev
+sudo apt install cmake # get CMake 2.8.7 first
+sudo apt install libcurl4-openssl-dev
 cd && mkdir -p repos && cd repos
 git clone https://github.com/kitware/cmake
 cd cmake

--- a/install-cwiid.md
+++ b/install-cwiid.md
@@ -9,5 +9,5 @@ This library is no longer maintained. See [Install XWiimote](./install-xwiimote.
 ## Install CWiiD (Ubuntu)
 
 ```bash
-sudo apt-get install libcwiid-dev
+sudo apt install libcwiid-dev
 ```

--- a/install-eigen.md
+++ b/install-eigen.md
@@ -7,7 +7,7 @@ This package contains the Eigen C++ template library and development files.
 Installing Eigen3 on Ubuntu is quite straightforward. Note that you will be prompted for your password upon using `sudo`. Type:
 
 ```bash
-sudo apt-get install libeigen3-dev
+sudo apt install libeigen3-dev
 ```
 
 ## Install Eigen3 (Windows)

--- a/install-glib.md
+++ b/install-glib.md
@@ -5,5 +5,5 @@ Official reference manual and downloads: [link](https://developer.gnome.org/glib
 ## Install GLib (Ubuntu)
 
 ```bash
-sudo apt-get install libglib2.0-dev
+sudo apt install libglib2.0-dev
 ```

--- a/install-mbrola.md
+++ b/install-mbrola.md
@@ -5,7 +5,7 @@ We use MBROLA Voices for speech synthesis. Official download page: [link](http:/
 ## Install MBROLA Voices (Ubuntu)
 
 ```bash
-sudo apt-get install espeak libespeak-dev
-sudo apt-get install mbrola-en1
-sudo apt-get install mbrola-es1
+sudo apt install espeak libespeak-dev
+sudo apt install mbrola-en1
+sudo apt install mbrola-es1
 ```

--- a/install-numpy.md
+++ b/install-numpy.md
@@ -12,5 +12,5 @@ $ sudo -H pip install numpy
 # Install Numpy using the Ubuntu package manager
 
 ```bash
-$ sudo apt-get install python-numpy
+$ sudo apt install python-numpy
 ```

--- a/install-opencv.md
+++ b/install-opencv.md
@@ -5,7 +5,7 @@ We use OpenCV for real-time computer vision. Official download page: [link](http
 ## Install OpenCV (Ubuntu)
 
 ```bash
-sudo apt-get install libopencv-dev
+sudo apt install libopencv-dev
 ```
 
 ## Install OpenCV 3 (With contrib and Python 3 support)
@@ -13,33 +13,33 @@ Adapted from [this post](http://www.pyimagesearch.com/2015/07/20/install-opencv-
 
 1. Upgrade any pre-installed packages:
    ```bash
-   $ sudo apt-get update
-   $ sudo apt-get upgrade
+   $ sudo apt update
+   $ sudo apt upgrade
    ```
 
 2. Install developer tools used to compile OpenCV 3.0:
    ```bash
-   $ sudo apt-get install build-essential cmake git pkg-config
+   $ sudo apt install build-essential cmake git pkg-config
    ```
 
 3. Install libraries and packages used to read various image and video formats from disk:
    ```bash
-   $ sudo apt-get install libjpeg8-dev libtiff4-dev libjasper-dev libpng12-dev
-   $ sudo apt-get install libavcodec-dev libavformat-dev libswscale-dev libv4l-dev
+   $ sudo apt install libjpeg8-dev libtiff4-dev libjasper-dev libpng12-dev
+   $ sudo apt install libavcodec-dev libavformat-dev libswscale-dev libv4l-dev
    ```
 4. Install GTK so we can use OpenCV’s GUI features:
    ```
-   $ sudo apt-get install libgtk2.0-dev
+   $ sudo apt install libgtk2.0-dev
    ```
 
 5. Install packages that are used to optimize various functions inside OpenCV, such as matrix operations:
    ```
-   $ sudo apt-get install libatlas-base-dev gfortran
+   $ sudo apt install libatlas-base-dev gfortran
    ```
 
 6. Install the Python 3.4+ headers and development files:
    ```
-   $ sudo apt-get install python3.4-dev
+   $ sudo apt install python3.4-dev
    ```
 
 7. [Install pip](install-pip.md)

--- a/install-openni-nite.md
+++ b/install-openni-nite.md
@@ -5,15 +5,15 @@ We use OpenNI2 for ASUS and Kinect support.
 ## Install Xtion Pro Live OpenNI driver (Ubuntu)
 
 ```bash
-sudo apt-get install libopenni-sensor-primesense0 
+sudo apt install libopenni-sensor-primesense0 
 ```
 
 ## Install OpenNI2 (Ubuntu)
 
 ```bash
-sudo apt-get install git libusb-1.0-0-dev libudev-dev  # libpcl-dev & pcl-tools instead of libpcl-all-dev as of Dic/2015
-sudo apt-get install openjdk-6-jdk  # if not using other java version
-sudo apt-get install freeglut3-dev
+sudo apt install git libusb-1.0-0-dev libudev-dev  # libpcl-dev & pcl-tools instead of libpcl-all-dev as of Dic/2015
+sudo apt install openjdk-6-jdk  # if not using other java version
+sudo apt install freeglut3-dev
 cd  # go home
 mkdir -p repos; cd repos  # create $HOME/repos if it doesn't exist; then, enter it
 git clone https://github.com/occipital/OpenNI2.git  # We used to have a fork off 6857677beee08e264fc5aeecb1adf647a7d616ab with working copy of Xtion Pro Live OpenNI2 driver.

--- a/install-openrave.md
+++ b/install-openrave.md
@@ -10,12 +10,12 @@ We use the OpenRAVE core library for simulations. Note that you will be prompted
 No official PPA, install from source.
 
 ```bash
-sudo apt-get install git
-sudo apt-get install libboost-all-dev
-sudo apt-get install libqt4-dev qt4-dev-tools libxml2-dev libode-dev
-sudo apt-get install libsoqt4-dev libcoin80-dev
-sudo apt-get install python-sympy python-scipy  # For openravepy
-sudo apt-get install libcollada-dom2.4-dp-dev  # Open .zae files
+sudo apt install git
+sudo apt install libboost-all-dev
+sudo apt install libqt4-dev qt4-dev-tools libxml2-dev libode-dev
+sudo apt install libsoqt4-dev libcoin80-dev
+sudo apt install python-sympy python-scipy  # For openravepy
+sudo apt install libcollada-dom2.4-dp-dev  # Open .zae files
 cd  # go home
 mkdir -p repos; cd repos  # create $HOME/repos if it doesn't exist; then, enter it
 git clone --branch master https://github.com/rdiankov/openrave.git
@@ -26,14 +26,14 @@ sudo make install; cd  # install and go home
 
 Note that you may end up requiring over 2 GB of free space during the installation of `apt` dependencies. To avoid that, use the `--no-install-recommends` option as in:
 
-`sudo apt-get install --no-install-recommends package`
+`sudo apt install --no-install-recommends package`
 
 Thus, `apt` would not try to install non-critical packages marked as *recommended* by the dependencies of OpenRAVE.
 
 ## Install OpenRAVE with FCL (Confirmed for Ubuntu 15.04, 15.10, 16.10, 17.04)
 
 ```bash
-sudo apt-get install libfcl-dev
+sudo apt install libfcl-dev
 cd $HOME/repos/openrave; mkdir build; cd build; cmake .. -DOPENRAVE_PLUGIN_FCLRAVE=ON
 make -j$(nproc)
 sudo make install; cd  # install and go home

--- a/install-pcl.md
+++ b/install-pcl.md
@@ -10,9 +10,9 @@ For Trusty and similar versions, we need to add the jochen-sprickerhof PPA [[ref
 
 ```bash
 sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl
-sudo apt-get update
-sudo apt-get install libpcl-all libpcl-all-dev
-sudo apt-get install libopenni-sensor-primesense0 # no pcl-tools here; and libopenni-sensor-pointclouds0 cannot be installed simultaneously.
+sudo apt update
+sudo apt install libpcl-all libpcl-all-dev
+sudo apt install libopenni-sensor-primesense0 # no pcl-tools here; and libopenni-sensor-pointclouds0 cannot be installed simultaneously.
 ```
 
 ## Install PCL 1.7.2-3~utopic1 with VTK (Ubuntu 14.10)
@@ -21,9 +21,9 @@ For Utopic and similar versions, we need to add the jochen-sprickerhof PPA [[ref
 
 ```bash
 sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl
-sudo apt-get update
-sudo apt-get install libpcl-dev
-sudo apt-get install pcl-tools # no sensor here, but libopenni-sensor-primesense0 may be found elsewhere
+sudo apt update
+sudo apt install libpcl-dev
+sudo apt install pcl-tools # no sensor here, but libopenni-sensor-primesense0 may be found elsewhere
 ```
 
 ## Install PCL 1.7.2-14build1 with VTK 6.2.0+dfsg1-10build1 (Ubuntu 16.04)
@@ -31,7 +31,7 @@ sudo apt-get install pcl-tools # no sensor here, but libopenni-sensor-primesense
 PCL is available directly as part of `universe` in modern Ubuntu distros [[ref](https://launchpad.net/ubuntu/+source/pcl)].
 
 ```bash
-sudo apt-get install libpcl-dev  # depends: libvtk6-dev
+sudo apt install libpcl-dev  # depends: libvtk6-dev
 ```
 
 ## Install PCL (From source)

--- a/install-pygame.md
+++ b/install-pygame.md
@@ -7,5 +7,5 @@ Official page: [link] (http://pygame.org/hifi.html)
 ## Install Pygame (Ubuntu)
 
 ```bash
-sudo apt-get install python-pygame
+sudo apt install python-pygame
 ```

--- a/install-ros.md
+++ b/install-ros.md
@@ -10,8 +10,8 @@ sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net --recv-key 421C365
 
 Download and install ROS
 ```bash
-sudo apt-get update
-sudo apt-get install git python-rosinstall ros-indigo-desktop-full python-catkin-tools ros-indigo-joint-state-controller ros-indigo-twist-mux ros-indigo-ompl ros-indigo-controller-manager ros-indigo-moveit-core ros-indigo-moveit-ros-perception ros-indigo-moveit-ros-move-group ros-indigo-moveit-kinematics ros-indigo-moveit-ros-planning-interface ros-indigo-moveit-simple-controller-manager ros-indigo-moveit-planners-ompl ros-indigo-joy ros-indigo-joy-teleop ros-indigo-teleop-tools ros-indigo-control-toolbox ros-indigo-sound-play ros-indigo-navigation ros-indigo-eband-local-planner ros-indigo-depthimage-to-laserscan  ros-indigo-openslam-gmapping ros-indigo-gmapping ros-indigo-moveit-commander ros-indigo-geometry-experimental
+sudo apt update
+sudo apt install git python-rosinstall ros-indigo-desktop-full python-catkin-tools ros-indigo-joint-state-controller ros-indigo-twist-mux ros-indigo-ompl ros-indigo-controller-manager ros-indigo-moveit-core ros-indigo-moveit-ros-perception ros-indigo-moveit-ros-move-group ros-indigo-moveit-kinematics ros-indigo-moveit-ros-planning-interface ros-indigo-moveit-simple-controller-manager ros-indigo-moveit-planners-ompl ros-indigo-joy ros-indigo-joy-teleop ros-indigo-teleop-tools ros-indigo-control-toolbox ros-indigo-sound-play ros-indigo-navigation ros-indigo-eband-local-planner ros-indigo-depthimage-to-laserscan  ros-indigo-openslam-gmapping ros-indigo-gmapping ros-indigo-moveit-commander ros-indigo-geometry-experimental
 ```
 
 extend the environment to include the catkin commands in any new opened console

--- a/install-spacenav.md
+++ b/install-spacenav.md
@@ -9,7 +9,7 @@ Official page: [link](http://spacenav.sourceforge.net/).
 You'll get the development files from:
 
 ```bash
-sudo apt-get install libspnav-dev
+sudo apt install libspnav-dev
 ```
 
 Includes the `spacenavd` daemon.

--- a/install-speech-recognition.md
+++ b/install-speech-recognition.md
@@ -6,10 +6,10 @@ We use Speech Recognition for give voice orders.
 
 ```bash
 # Speech Recognition: 
-sudo apt-get install libgstreamer1.0-dev
-sudo apt-get install libgstreamer-plugins-base1.0-dev
-sudo apt-get install autoconf
-sudo apt-get install bison
+sudo apt install libgstreamer1.0-dev
+sudo apt install libgstreamer-plugins-base1.0-dev
+sudo apt install autoconf
+sudo apt install bison
 
 # Install sphinxbase
 cd

--- a/install-xwiimote.md
+++ b/install-xwiimote.md
@@ -7,11 +7,11 @@ Linux device driver and utilities: [link](https://github.com/dvdhrm/xwiimote). W
 ## Install XWiimote (Ubuntu)
 
 ```bash
-sudo apt-get install libxwiimote-dev
+sudo apt install libxwiimote-dev
 ```
 
 To get the `xwiishow` tool (handy `ncurses`-based GUI for testing):
 
 ```bash
-sudo apt-get install xwiimote
+sudo apt install xwiimote
 ```

--- a/install-yarp.md
+++ b/install-yarp.md
@@ -13,11 +13,11 @@ Official download page: [link](http://www.yarp.it/)
 As can be seen, here we are accounting for: YARP `lib_math`, the GUIs and `mjpeg` carrier.
 
 ```bash
-sudo apt-get install build-essential libace-dev subversion git
-sudo apt-get install libeigen3-dev  # Needed for creating YARP lib_math used for kinematics, etc.
-sudo apt-get install qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qtdeclarative5-qtquick2-plugin qtdeclarative5-window-plugin qtdeclarative5-qtmultimedia-plugin qtdeclarative5-controls-plugin qtdeclarative5-dialogs-plugin libqt5svg5
-sudo apt-get install libjpeg8-dev   # Needed for mjpeg carrier
-sudo apt-get install libedit-dev  # Enables keyboard arrow keys within an RPC communication channel via terminal
+sudo apt install build-essential libace-dev subversion git
+sudo apt install libeigen3-dev  # Needed for creating YARP lib_math used for kinematics, etc.
+sudo apt install qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev qtdeclarative5-qtquick2-plugin qtdeclarative5-window-plugin qtdeclarative5-qtmultimedia-plugin qtdeclarative5-controls-plugin qtdeclarative5-dialogs-plugin libqt5svg5
+sudo apt install libjpeg8-dev   # Needed for mjpeg carrier
+sudo apt install libedit-dev  # Enables keyboard arrow keys within an RPC communication channel via terminal
 cd  # go home
 mkdir -p repos; cd repos  # create $HOME/repos if it doesn't exist; then, enter it
 git clone https://github.com/robotology/yarp
@@ -46,14 +46,14 @@ sudo make install; sudo ldconfig; cd # install and go home
 
 Swig is needed in order to build the python bindings. It is normally installed with
 ```bash
-sudo apt-get update
-sudo apt-get install swig
-sudo apt-get install libpython-dev  # not installed by default on clean distros
+sudo apt update
+sudo apt install swig
+sudo apt install libpython-dev  # not installed by default on clean distros
 ```
 
 **Note:** If you are on Ubuntu Trusty (14.04), you have to install swig3.0 instead of swig
 ```bash
-sudo apt-get install swig3.0
+sudo apt install swig3.0
 ```
 
 Make sure you have installed previously YARP.
@@ -87,7 +87,7 @@ You may need to launch `yarpdev --device OpenNI2DeviceServer` from /YOUR_PATH_TO
 
 ## Note for Linux Mint 17.3 Rosa
 ```bash
-sudo apt-get install libqt5opengl5-dev  # avoid error on yarpmanager/builder GUI
+sudo apt install libqt5opengl5-dev  # avoid error on yarpmanager/builder GUI
 ```
 
 

--- a/install-ycm.md
+++ b/install-ycm.md
@@ -20,7 +20,7 @@ sudo make install; cd  # install and go home
 CMake-based projects may bootstrap YCM so that its sources are downloaded on demand - it's up to the developers to reflect this in the documentation. Under these assumptions, you should not worry about the previous installation step as everything would land in your project's `<build-tree>/install` directory by default. However, you may want to avoid this process (and the subsequent need for Internet connection) by installing YCM in your system paths - in this respect, please refer to the previous section. Additionally, it must be noted that bootstrapping YCM itself as well as downloading any remote package integrated in the superbuild requires that an appropriate VCS client is installed on the system. Usually, these projects are Git-based and all you need to do is to install `git` (we assume you did this already):
 
 ```bash
-sudo apt-get install git
+sudo apt install git
 ```
 
 Remember to configure your Git username and email ([YCM and Git](#ycm-and-git)).


### PR DESCRIPTION
* replacement of `apt-get` by `apt`  except in installation sections with Ubuntu 12.04 and debian 6.0
* sections with Ubuntu 12.04 and debian 6.0 (not changed): `install-cmake.md` , `install-yarp.md` and `install-openrave.md` 