### PR TITLE
Install tensorflow_cc guide added

### DIFF
--- a/install-tensorflow.md
+++ b/install-tensorflow.md
@@ -2,7 +2,7 @@
 
 We use TensorFlow as a Keras backend. Official page: [link](https://www.tensorflow.org/install/)
 
-Also see [install-tensorflow_cc](install-tensorflow_cc.md) for the CMake'd alternative (this official one uses Bazel).
+Also see [install-tensorflow_cc](install-tensorflow_cc.md) for an alternative that is more prepared for use with CMake.
 
 ## Dependencies for building TensorFlow
 To build TensorFlow from source (e.g. for GPU support), you'll need:

--- a/install-tensorflow.md
+++ b/install-tensorflow.md
@@ -1,8 +1,8 @@
 # Install TensorFlow
 
-We use TensorFlow as a Keras backend
+We use TensorFlow as a Keras backend. Official page: [link](https://www.tensorflow.org/install/)
 
-Official page: [link](https://www.tensorflow.org/install/)
+Also see [install-tensorflow_cc](install-tensorflow_cc.md) for the CMake'd alternative (this official one uses Bazel).
 
 ## Dependencies for building TensorFlow
 To build TensorFlow from source (e.g. for GPU support), you'll need:

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -2,56 +2,22 @@
 
 We use `tensorflow_cc` for Tensorflow C++ API. Use `cmake` to build your project using `tensorflow_cc` as library. Official page: [link](https://github.com/FloopCZ/tensorflow_cc)
 
-- [Install tensorflow_cc (Ubuntu 18.04)](#install-tensorflow_cc-ubuntu-1804)
-- [Install tensorflow_cc (Ubuntu 14.04 and 16.04)](#install-tensorflow_cc-ubuntu-1404-and-1604)
+- [Install dependencies (Ubuntu 18.04)](#install-dependencies-ubuntu-1804)
+- [Install dependencies (Ubuntu 14.04 and 16.04)](#install-dependencies-ubuntu-1404-and-1604)
+- [Install tensorflow_cc (Ubuntu)](#install-tensorflow_cc-ubuntu)
+- [Troubleshooting](#troubleshooting)
 
-
-## Install tensorflow_cc (Ubuntu 18.04)
+## Install dependencies (Ubuntu 18.04)
 
 Download and install requirements.
 
 ```bash
-
 sudo apt-get install build-essential curl git cmake unzip autoconf autogen automake libtool mlocate \
                      zlib1g-dev g++-7 python python3-numpy python3-dev python3-pip python3-wheel wget
 sudo updatedb
 ```
-There are two diferent types of libraries, static and shared.
 
-### Static library
-
-- Default
-- Faster to build
-- No GPU support
-- Basic functionalities
-
-Download and install `tensorflow_cc::Static`.
-
-```bash
-git clone https://github.com/FloopCZ/tensorflow_cc.git
-cd tensorflow_cc/tensorflow_cc
-mkdir build && cd build
-cmake ..
-make && sudo make install
-```
-### Shared library
-
-- Requires install [bazel](https://github.com/roboticslab-uc3m/installation-guides/blob/master/install-bazel.md)
-- Slower to build
-- GPU support
-- Full Tensorflow C++ API
-
-Download and install `tensorflow_cc::Shared`.
-
-```bash
-git clone https://github.com/FloopCZ/tensorflow_cc.git
-cd tensorflow_cc/tensorflow_cc
-mkdir build && cd build
-cmake -DTENSORFLOW_STATIC=OFF -DTENSORFLOW_SHARED=ON ..
-make && sudo make install
-```
-## Install tensorflow_cc (Ubuntu 14.04 and 16.04)
-
+## Install dependencies (Ubuntu 14.04 and 16.04)
 Download and install requirements.
 ```bash
 
@@ -72,19 +38,19 @@ sudo apt-get update -y && \
 sudo apt-get install gcc-7 g++-7 -y && \
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7 && \
 sudo update-alternatives --config gcc
-
 ```
 
-There are two diferent types of libraries, static and shared.
+## Install tensorflow_cc (Ubuntu)
+You can create two diferent types of libraries: static or shared.
 
 ### Static library
-
+Will create CMake target `tensorflow_cc::Static`.
 - Default
 - Faster to build
 - No GPU support
 - Basic functionalities
 
-Download and install `tensorflow_cc::Static`.
+Download and install:
 ```bash
 git clone https://github.com/FloopCZ/tensorflow_cc.git
 cd tensorflow_cc/tensorflow_cc
@@ -92,14 +58,15 @@ mkdir build && cd build
 cmake ..
 make && sudo make install
 ```
-### Shared library
 
+### Shared library
+Will create CMake target `tensorflow_cc::Shared`.
 - Requires install [bazel](https://github.com/roboticslab-uc3m/installation-guides/blob/master/install-bazel.md)
 - Slower to build
 - GPU support
 - Full Tensorflow C++ API
 
-Download and install `tensorflow_cc::Shared`.
+Download and install:
 ```bash
 git clone https://github.com/FloopCZ/tensorflow_cc.git
 cd tensorflow_cc/tensorflow_cc
@@ -108,11 +75,9 @@ cmake -DTENSORFLOW_STATIC=OFF -DTENSORFLOW_SHARED=ON ..
 make && sudo make install
 ```
 
-## Note for Intel CPU older than ivybridge
-
+# Troubleshooting
+### Note for Intel CPU older than ivybridge
 Intel CPU older than *[ivybridge](https://ark.intel.com/content/www/es/es/ark/products/codename/29902/ivy-bridge.html)*:
 ```bash
-
 export CC_OPT_FLAGS="-march=native"
-
 ```

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -25,7 +25,7 @@ There are two diferent types of libraries, static and shared.
 - No GPU support
 - Basic functionalities
 
-Download and install `tensorflow_cc`.
+Download and install `tensorflow_cc::Static`.
 
 ```bash
 git clone https://github.com/FloopCZ/tensorflow_cc.git
@@ -41,7 +41,7 @@ make && sudo make install
 - GPU support
 - Full Tensorflow C++ API
 
-Download and install `tensorflow_cc`.
+Download and install `tensorflow_cc::Shared`.
 
 ```bash
 git clone https://github.com/FloopCZ/tensorflow_cc.git

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -9,7 +9,7 @@ We use `tensorflow_cc` for Tensorflow C++ API without using Bazel. Official page
 
 Installing `tensorflow_cc` on Ubuntu to use Tensorflow C++ API without using `bazel`. Use `cmake` to build your project using `tensorflow_cc` as library to access Tensorflow C++ API.
 
-Installing `tensorflow_cc` requeriments.
+Installing `tensorflow_cc` requirements.
 
 ```bash
 

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -1,6 +1,6 @@
 # Install tensorflow_cc
 
-We use `tensorflow_cc` for Tensorflow C++ API without using Bazel.Use `cmake` to build your project using `tensorflow_cc` as library. Official page: [link](https://github.com/FloopCZ/tensorflow_cc)
+We use `tensorflow_cc` for Tensorflow C++ API. Use `cmake` to build your project using `tensorflow_cc` as library. Official page: [link](https://github.com/FloopCZ/tensorflow_cc)
 
 - [Install tensorflow_cc (Ubuntu 18.04)](#install-tensorflow_cc-(Ubuntu-18.04))
 - [Install tensorflow_cc (Ubuntu 14.04 and 16.04)](#install-tensorflow_cc-(Ubuntu-14.04-and-16.04))

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -101,7 +101,7 @@ cmake -DTENSORFLOW_STATIC=OFF -DTENSORFLOW_SHARED=ON ..
 make && sudo make install
 ```
 
-## Note for Intel CPU oldet than ivybridge
+## Note for Intel CPU older than ivybridge
 
 Intel CPU older than *[ivybridge](https://ark.intel.com/es-es/products/codename/29902/Ivy-Bridge)*:
 ```bash

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -2,11 +2,11 @@
 
 We use `tensorflow_cc` for Tensorflow C++ API. Use `cmake` to build your project using `tensorflow_cc` as library. Official page: [link](https://github.com/FloopCZ/tensorflow_cc)
 
-- [Install tensorflow_cc (Ubuntu 18.04)](#install-tensorflow_cc-(Ubuntu-18.04))
-- [Install tensorflow_cc (Ubuntu 14.04 and 16.04)](#install-tensorflow_cc-(Ubuntu-14.04-and-16.04))
+- [Install tensorflow_cc (Ubuntu 18.04)](#ubuntu-18.04)
+- [Install tensorflow_cc (Ubuntu 14.04 and 16.04)](#ubuntu-14.04-16.04)
 
 
-## Install tensorflow_cc (Ubuntu 18.04)
+## Install tensorflow_cc (Ubuntu 18.04)<a name="ubuntu-18.04"></a>
 
 Download and install requirements.
 
@@ -47,7 +47,7 @@ mkdir build && cd build
 cmake -DTENSORFLOW_STATIC=OFF -DTENSORFLOW_SHARED=ON ..
 make && sudo make install
 ```
-## Install tensorflow_cc (Ubuntu 14.04 and 16.04)
+## Install tensorflow_cc (Ubuntu 14.04 and 16.04)<a name="ubuntu-14.04-16.04"></a>
 
 Download and install requirements.
 ```bash

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -103,7 +103,7 @@ make && sudo make install
 
 ## Note for Intel CPU older than ivybridge
 
-Intel CPU older than *[ivybridge](https://ark.intel.com/es-es/products/codename/29902/Ivy-Bridge)*:
+Intel CPU older than *[ivybridge](https://ark.intel.com/content/www/es/es/ark/products/codename/29902/ivy-bridge.html)*:
 ```bash
 
 export CC_OPT_FLAGS="-march=native"

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -1,0 +1,141 @@
+# Install tensorflow_cc
+
+- [Introduction](#introduction)
+- [Requeriments](#requeriments)
+- [Install Ubuntu 18.04 requirements](#install-ubuntu-18.04-requirements)
+- [Install Ubuntu 14.04 requirements](#install-ubuntu-14.04-requirements)
+- [Install tensorflow_cc](#install-tensorflow_cc)
+- [Add tensorflow_cc to cmake project](add-tensorflow_cc-to-cmake-project)
+- [Original source](#original-source)
+
+## Introduction
+
+Install `tensorflow_cc` to use Tensorflow C++ API without using `bazel`. Use `cmake` to build your project using `tensorflow_cc` as library to use Tensorflow C++ API.
+
+## Requirements
+
+Install your distro requirements.
+
+### Install Ubuntu 18.04 requirements
+
+1. Install `Ubuntu 18.04` requirements:
+
+```bash
+
+sudo apt-get install build-essential curl git cmake unzip autoconf autogen automake libtool mlocate \
+                     zlib1g-dev g++-7 python python3-numpy python3-dev python3-pip python3-wheel wget
+sudo updatedb
+
+```
+
+### Install Ubuntu 14.04 requirements
+
+1. Install `Ubuntu 14.04` requirements:
+
+```bash
+
+sudo apt-get install build-essential curl git cmake unzip autoconf autogen automake libtool mlocate \
+                     zlib1g-dev python python3-numpy python3-dev python3-pip python3-wheel wget
+sudo updatedb
+
+```
+
+2. Install `GCC7`:
+
+Ubuntu 14.04 `Trusty` doesn´t support `GCC7` in standard repositories. You´ll need to add externar repository
+
+```bash
+
+sudo apt-get update -y && \
+sudo apt-get upgrade -y && \
+sudo apt-get dist-upgrade -y && \
+sudo apt-get install build-essential software-properties-common -y && \
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
+sudo apt-get update -y && \
+sudo apt-get install gcc-7 g++-7 -y && \
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7 && \
+sudo update-alternatives --config gcc
+
+```
+
+## Install tensorflow_cc
+
+1. Clone ´tensorflow_cc` repository:
+
+```bash
+
+git clone https://github.com/FloopCZ/tensorflow_cc.git
+cd tensorflow_cc
+
+```
+
+2. Build and install ´tensorflow_cc` as a library:
+
+There are two diferent types of libraries, shared and static.
+
+**Static library:**
+
+- Default
+- Faster to build
+- No GPU support
+- Basic functionalities
+
+
+```bash
+cd tensorflow_cc
+mkdir build && cd build
+cmake ..
+make && sudo make install
+```
+**Shared library:**
+
+- Requires install [bazel](https://github.com/roboticslab-uc3m/installation-guides/blob/master/install-bazel.md)
+- Slower to build
+- GPU support
+- Full Tensorflow C++ API
+
+```bash
+cd tensorflow_cc
+mkdir build && cd build
+# for shared library only (requires Bazel):
+cmake -DTENSORFLOW_STATIC=OFF -DTENSORFLOW_SHARED=ON ..
+make && sudo make install
+```
+
+**WARNING:** Intel CPU older than *[ivybridge](https://ark.intel.com/es-es/products/codename/29902/Ivy-Bridge)*:
+```bash
+
+export CC_OPT_FLAGS="-march=native"
+
+``` 
+
+## Add tensorflow_cc to cmake project
+
+
+Add to your `CMakeLists.txt` as a library
+```bash
+
+find_package(TensorflowCC REQUIRED)
+
+# Link the static Tensorflow library.
+target_link_libraries(project_name TensorflowCC::Static)
+
+# Altenatively, link the shared Tensorflow library.
+# target_link_libraries(project_name TensorflowCC::Shared)
+
+```
+
+If you use `Shared` library `CUDA` is available.
+
+```bash
+
+# For shared library setting, you may also link cuda if it is available.
+# find_package(CUDA)
+# if(CUDA_FOUND)
+#   target_link_libraries(example ${CUDA_LIBRARIES})
+# endif()
+
+```
+## Original source
+
+[FloopCZ: tensorflow_cc](https://github.com/FloopCZ/tensorflow_cc) project.

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -25,6 +25,7 @@ There are two diferent types of libraries, static and shared.
 - No GPU support
 - Basic functionalities
 
+Download and install `tensorflow_cc`.
 
 ```bash
 git clone https://github.com/FloopCZ/tensorflow_cc.git
@@ -39,6 +40,8 @@ make && sudo make install
 - Slower to build
 - GPU support
 - Full Tensorflow C++ API
+
+Download and install `tensorflow_cc`.
 
 ```bash
 git clone https://github.com/FloopCZ/tensorflow_cc.git

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -2,6 +2,8 @@
 
 We use `tensorflow_cc` for Tensorflow C++ API. Use `cmake` to build your project using `tensorflow_cc` as library. Official page: [link](https://github.com/FloopCZ/tensorflow_cc)
 
+Also see [install-tensorflow](install-tensorflow.md) for the official alternative (less prepared for use with CMake).
+
 - [Install dependencies (Ubuntu 18.04)](#install-dependencies-ubuntu-1804)
 - [Install dependencies (Ubuntu 14.04 and 16.04)](#install-dependencies-ubuntu-1404-and-1604)
 - [Install tensorflow_cc (Ubuntu)](#install-tensorflow_cc-ubuntu)

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -74,6 +74,9 @@ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /u
 sudo update-alternatives --config gcc
 
 ```
+
+There are two diferent types of libraries, static and shared.
+
 ### Static library
 
 - Default

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -2,11 +2,11 @@
 
 We use `tensorflow_cc` for Tensorflow C++ API. Use `cmake` to build your project using `tensorflow_cc` as library. Official page: [link](https://github.com/FloopCZ/tensorflow_cc)
 
-- [Install tensorflow_cc (Ubuntu 18.04)](#ubuntu-18.04)
-- [Install tensorflow_cc (Ubuntu 14.04 and 16.04)](#ubuntu-14.04-16.04)
+- [Install tensorflow_cc (Ubuntu 18.04)](#install-tensorflow_cc-ubuntu-1804)
+- [Install tensorflow_cc (Ubuntu 14.04 and 16.04)](#install-tensorflow_cc-ubuntu-1404-and-1604)
 
 
-## Install tensorflow_cc (Ubuntu 18.04)<a name="ubuntu-18.04"></a>
+## Install tensorflow_cc (Ubuntu 18.04)
 
 Download and install requirements.
 
@@ -50,7 +50,7 @@ mkdir build && cd build
 cmake -DTENSORFLOW_STATIC=OFF -DTENSORFLOW_SHARED=ON ..
 make && sudo make install
 ```
-## Install tensorflow_cc (Ubuntu 14.04 and 16.04)<a name="ubuntu-14.04-16.04"></a>
+## Install tensorflow_cc (Ubuntu 14.04 and 16.04)
 
 Download and install requirements.
 ```bash

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -8,6 +8,7 @@ We use `tensorflow_cc` for Tensorflow C++ API without using Bazel. Official page
 # Install tensorflow_cc (Ubuntu)
 
 Installing `tensorflow_cc` on Ubuntu to use Tensorflow C++ API without using `bazel`. Use `cmake` to build your project using `tensorflow_cc` as library to access Tensorflow C++ API.
+
 Installing `tensorflow_cc` requeriments.
 
 ```bash

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -69,7 +69,7 @@ cd tensorflow_cc
 
 ```
 
-2. Build and install ´tensorflow_cc` as a library:
+2. Build and install `tensorflow_cc` as a library:
 
 There are two diferent types of libraries, shared and static.
 

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -81,7 +81,7 @@ sudo update-alternatives --config gcc
 - No GPU support
 - Basic functionalities
 
-
+Download and install `tensorflow_cc::Static`.
 ```bash
 git clone https://github.com/FloopCZ/tensorflow_cc.git
 cd tensorflow_cc/tensorflow_cc
@@ -96,6 +96,7 @@ make && sudo make install
 - GPU support
 - Full Tensorflow C++ API
 
+Download and install `tensorflow_cc::Shared`.
 ```bash
 git clone https://github.com/FloopCZ/tensorflow_cc.git
 cd tensorflow_cc/tensorflow_cc

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -1,28 +1,24 @@
 # Install tensorflow_cc
 
-We use `tensorflow_cc` for Tensorflow C++ API without using Bazel. Official page: [link](https://github.com/FloopCZ/tensorflow_cc)
+We use `tensorflow_cc` for Tensorflow C++ API without using Bazel.Use `cmake` to build your project using `tensorflow_cc` as library. Official page: [link](https://github.com/FloopCZ/tensorflow_cc)
 
-- [Install tensorflow_cc (Ubuntu)](#install-tensorflow_cc-(Ubuntu))
+- [Install tensorflow_cc (Ubuntu 18.04)](#install-tensorflow_cc-(Ubuntu-18.04))
+- [Install tensorflow_cc (Ubuntu 14.04 and 16.04)](#install-tensorflow_cc-(Ubuntu-14.04-and-16.04))
 
 
-# Install tensorflow_cc (Ubuntu)
+## Install tensorflow_cc (Ubuntu 18.04)
 
-Installing `tensorflow_cc` on Ubuntu to use Tensorflow C++ API without using `bazel`. Use `cmake` to build your project using `tensorflow_cc` as library to access Tensorflow C++ API.
-
-Installing `tensorflow_cc` requirements.
+Download and install requirements.
 
 ```bash
 
 sudo apt-get install build-essential curl git cmake unzip autoconf autogen automake libtool mlocate \
                      zlib1g-dev g++-7 python python3-numpy python3-dev python3-pip python3-wheel wget
 sudo updatedb
-git clone https://github.com/FloopCZ/tensorflow_cc.git
-cd tensorflow_cc
-
 ```
 There are two diferent types of libraries, shared and static.
 
-**Static library:**
+### Static library
 
 - Default
 - Faster to build
@@ -31,12 +27,13 @@ There are two diferent types of libraries, shared and static.
 
 
 ```bash
-cd tensorflow_cc
+git clone https://github.com/FloopCZ/tensorflow_cc.git
+cd tensorflow_cc/tensorflow_cc
 mkdir build && cd build
 cmake ..
 make && sudo make install
 ```
-**Shared library:**
+### Shared library
 
 - Requires install [bazel](https://github.com/roboticslab-uc3m/installation-guides/blob/master/install-bazel.md)
 - Slower to build
@@ -44,16 +41,22 @@ make && sudo make install
 - Full Tensorflow C++ API
 
 ```bash
-cd tensorflow_cc
+git clone https://github.com/FloopCZ/tensorflow_cc.git
+cd tensorflow_cc/tensorflow_cc
 mkdir build && cd build
 cmake -DTENSORFLOW_STATIC=OFF -DTENSORFLOW_SHARED=ON ..
 make && sudo make install
 ```
+## Install tensorflow_cc (Ubuntu 14.04 and 16.04)
 
-## Note for Ubuntu 14.04 & 16.04
+Download and install requirements.
+```bash
 
-Ubuntu 14.04 & 16.04 doesn´t allow GCC7 installation direcly, you should add `ubuntu-toolchain-r/test` repository to install.
-
+sudo apt-get install build-essential curl git cmake unzip autoconf autogen automake libtool mlocate \
+                     zlib1g-dev python python3-numpy python3-dev python3-pip python3-wheel wget
+sudo updatedb
+```
+Ubuntu 14.04 and 16.04 doesn´t allow GCC7 installation direcly, you should add `ubuntu-toolchain-r/test` repository to install.
 
 ```bash
 
@@ -68,7 +71,35 @@ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /u
 sudo update-alternatives --config gcc
 
 ```
+### Static library
 
+- Default
+- Faster to build
+- No GPU support
+- Basic functionalities
+
+
+```bash
+git clone https://github.com/FloopCZ/tensorflow_cc.git
+cd tensorflow_cc/tensorflow_cc
+mkdir build && cd build
+cmake ..
+make && sudo make install
+```
+### Shared library
+
+- Requires install [bazel](https://github.com/roboticslab-uc3m/installation-guides/blob/master/install-bazel.md)
+- Slower to build
+- GPU support
+- Full Tensorflow C++ API
+
+```bash
+git clone https://github.com/FloopCZ/tensorflow_cc.git
+cd tensorflow_cc/tensorflow_cc
+mkdir build && cd build
+cmake -DTENSORFLOW_STATIC=OFF -DTENSORFLOW_SHARED=ON ..
+make && sudo make install
+```
 
 ## Note for Intel CPU oldet than ivybridge
 

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -1,76 +1,24 @@
 # Install tensorflow_cc
 
-- [Introduction](#introduction)
-- [Requeriments](#requeriments)
-- [Install Ubuntu 18.04 requirements](#install-ubuntu-18.04-requirements)
-- [Install Ubuntu 14.04 requirements](#install-ubuntu-14.04-requirements)
-- [Install tensorflow_cc](#install-tensorflow_cc)
-- [Add tensorflow_cc to cmake project](add-tensorflow_cc-to-cmake-project)
-- [Original source](#original-source)
+We use `tensorflow_cc` for Tensorflow C++ API without using Bazel. Official page: [link](https://github.com/FloopCZ/tensorflow_cc)
 
-## Introduction
+- [Install tensorflow_cc (Ubuntu)](#install-tensorflow_cc-(Ubuntu))
 
-Install `tensorflow_cc` to use Tensorflow C++ API without using `bazel`. Use `cmake` to build your project using `tensorflow_cc` as library to use Tensorflow C++ API.
 
-## Requirements
+# Install tensorflow_cc (Ubuntu)
 
-Install your distro requirements.
-
-### Install Ubuntu 18.04 requirements
-
-1. Install `Ubuntu 18.04` requirements:
+Installing `tensorflow_cc` on Ubuntu to use Tensorflow C++ API without using `bazel`. Use `cmake` to build your project using `tensorflow_cc` as library to access Tensorflow C++ API.
+Installing `tensorflow_cc` requeriments.
 
 ```bash
 
 sudo apt-get install build-essential curl git cmake unzip autoconf autogen automake libtool mlocate \
                      zlib1g-dev g++-7 python python3-numpy python3-dev python3-pip python3-wheel wget
 sudo updatedb
-
-```
-
-### Install Ubuntu 14.04 requirements
-
-1. Install `Ubuntu 14.04` requirements:
-
-```bash
-
-sudo apt-get install build-essential curl git cmake unzip autoconf autogen automake libtool mlocate \
-                     zlib1g-dev python python3-numpy python3-dev python3-pip python3-wheel wget
-sudo updatedb
-
-```
-
-2. Install `GCC7`:
-
-Ubuntu 14.04 `Trusty` doesn´t support `GCC7` in standard repositories. You´ll need to add externar repository
-
-```bash
-
-sudo apt-get update -y && \
-sudo apt-get upgrade -y && \
-sudo apt-get dist-upgrade -y && \
-sudo apt-get install build-essential software-properties-common -y && \
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
-sudo apt-get update -y && \
-sudo apt-get install gcc-7 g++-7 -y && \
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7 && \
-sudo update-alternatives --config gcc
-
-```
-
-## Install tensorflow_cc
-
-1. Clone ´tensorflow_cc` repository:
-
-```bash
-
 git clone https://github.com/FloopCZ/tensorflow_cc.git
 cd tensorflow_cc
 
 ```
-
-2. Build and install `tensorflow_cc` as a library:
-
 There are two diferent types of libraries, shared and static.
 
 **Static library:**
@@ -97,45 +45,35 @@ make && sudo make install
 ```bash
 cd tensorflow_cc
 mkdir build && cd build
-# for shared library only (requires Bazel):
 cmake -DTENSORFLOW_STATIC=OFF -DTENSORFLOW_SHARED=ON ..
 make && sudo make install
 ```
 
-**WARNING:** Intel CPU older than *[ivybridge](https://ark.intel.com/es-es/products/codename/29902/Ivy-Bridge)*:
+## Note for Ubuntu 14.04 & 16.04
+
+Ubuntu 14.04 & 16.04 doesn´t allow GCC7 installation direcly, you should add `ubuntu-toolchain-r/test` repository to install.
+
+
+```bash
+
+sudo apt-get update -y && \
+sudo apt-get upgrade -y && \
+sudo apt-get dist-upgrade -y && \
+sudo apt-get install build-essential software-properties-common -y && \
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
+sudo apt-get update -y && \
+sudo apt-get install gcc-7 g++-7 -y && \
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7 && \
+sudo update-alternatives --config gcc
+
+```
+
+
+## Note for Intel CPU oldet than ivybridge
+
+Intel CPU older than *[ivybridge](https://ark.intel.com/es-es/products/codename/29902/Ivy-Bridge)*:
 ```bash
 
 export CC_OPT_FLAGS="-march=native"
 
-``` 
-
-## Add tensorflow_cc to cmake project
-
-
-Add to your `CMakeLists.txt` as a library
-```bash
-
-find_package(TensorflowCC REQUIRED)
-
-# Link the static Tensorflow library.
-target_link_libraries(project_name TensorflowCC::Static)
-
-# Altenatively, link the shared Tensorflow library.
-# target_link_libraries(project_name TensorflowCC::Shared)
-
 ```
-
-If you use `Shared` library `CUDA` is available.
-
-```bash
-
-# For shared library setting, you may also link cuda if it is available.
-# find_package(CUDA)
-# if(CUDA_FOUND)
-#   target_link_libraries(example ${CUDA_LIBRARIES})
-# endif()
-
-```
-## Original source
-
-[FloopCZ: tensorflow_cc](https://github.com/FloopCZ/tensorflow_cc) project.

--- a/install-tensorflow_cc.md
+++ b/install-tensorflow_cc.md
@@ -16,7 +16,7 @@ sudo apt-get install build-essential curl git cmake unzip autoconf autogen autom
                      zlib1g-dev g++-7 python python3-numpy python3-dev python3-pip python3-wheel wget
 sudo updatedb
 ```
-There are two diferent types of libraries, shared and static.
+There are two diferent types of libraries, static and shared.
 
 ### Static library
 


### PR DESCRIPTION
# Install tensorflow_cc
Tensorflow C++ API guide using `cmake` without `bazel`. Install `tensorflow_cc` guide added `commit`.  Adapted to `Ubuntu 14.04` and with `Ubuntu 18.04` guide.

## Original source
[FloopCZ/tensorflow_cc project](https://github.com/FloopCZ/tensorflow_cc) project. 